### PR TITLE
Fix build error in libapi-example.cpp

### DIFF
--- a/advanced/irods_api_example/src/libapi-example.cpp
+++ b/advanced/irods_api_example/src/libapi-example.cpp
@@ -39,7 +39,6 @@ int call_helloInp_helloOut(
     helloInp_t*       _inp,
     helloOut_t**      _out ) {
     return _api->call_handler<
-               rsComm_t*,
                helloInp_t*,
                helloOut_t** >(
                    _comm,


### PR DESCRIPTION
call_handler definition has moved such that the template list no longer needs to contain the rsComm_t*.

The change which breaks the build was introduced [here](https://github.com/irods/irods/commit/a2d43b753c8f0330564ddbf39b8dbab69be5b764). First discovered by [iRODS-Chat](https://groups.google.com/forum/#!topic/iROD-Chat/iLleH4x35wQ) user.