### PR TITLE
UGM 2023: Advanced Training - Compute to Data updates

### DIFF
--- a/advanced/hpc_compute_to_data/compute_to_data.py
+++ b/advanced/hpc_compute_to_data/compute_to_data.py
@@ -221,12 +221,12 @@ def container_dispatch(rule_args, callback, rei):
                     docker_opts ['volumes'][docker_host_output_path] = { 'bind': docker_guest_output_path, 'mode': 'rw' }
 
             # Must run as user 999 (iRODS service account) because iRODS vault uses permission 600
-            docker_opts['user'] = 999
+            docker_opts['user'] = 'jovyan'
             # Remove the container on exit
             docker_opts['remove'] = True
 
             docker_method = _resolve_docker_method (docker.from_env(), docker_cmd  )
- 
+
             # prepare target output directory
             task_output_colln = dst_colln + "/" + task_id
             callback.msiCollCreate (task_output_colln, "1", 0)

--- a/advanced/hpc_compute_to_data/compute_to_data.py
+++ b/advanced/hpc_compute_to_data/compute_to_data.py
@@ -220,7 +220,8 @@ def container_dispatch(rule_args, callback, rei):
                 if vault_paths.get ('output'):
                     docker_opts ['volumes'][docker_host_output_path] = { 'bind': docker_guest_output_path, 'mode': 'rw' }
 
-            # Must run as user 999 (iRODS service account) because iRODS vault uses permission 600
+            # Must run as user jovyan, which maps to the iRODS service account on the host. iRODS vault uses permission
+            # 600 by default, so the iRODS user is the only one that can see the files.
             docker_opts['user'] = 'jovyan'
             # Remove the container on exit
             docker_opts['remove'] = True

--- a/advanced/hpc_compute_to_data/jupyter_notebook/Dockerfile
+++ b/advanced/hpc_compute_to_data/jupyter_notebook/Dockerfile
@@ -1,6 +1,8 @@
 FROM jupyter/base-notebook
 
-ARG  irods_gid=999
+ARG  irods_uid=997
+ENV  IRODS_UID ${irods_uid}
+ARG  irods_gid=998
 ENV  IRODS_GID ${irods_gid}
 
 USER root
@@ -9,7 +11,7 @@ RUN apt-get update && apt-get install -y vim less
 
 RUN groupadd -g $IRODS_GID irods && usermod -aG irods jovyan 
 
-RUN sed -i "s/jovyan:x:[0-9]*:[0-9]*\(.*\)/jovyan:x:999:999\1/" /etc/passwd
+RUN sed -i "s/jovyan:x:[0-9]*:[0-9]*\(.*\)/jovyan:x:${IRODS_UID}:${IRODS_GID}\1/" /etc/passwd
 
 ADD lpfilter.ipynb /home/jovyan/work/.
 
@@ -21,7 +23,7 @@ COPY mymodule/ /home/jovyan/work/mymodule
 
 RUN chown -R jovyan.users /home/jovyan/work/mymodule
 
-RUN chown -R 999:999 /home/jovyan && chown -R 999:999 /opt/conda
+RUN chown -R ${IRODS_UID}:${IRODS_GID} /home/jovyan && chown -R ${IRODS_UID}:${IRODS_GID} /opt/conda
 
 USER jovyan
 


### PR DESCRIPTION
This change updates the Dockerfile used for the Jupyter notebook demonstration for the Compute to Data advanced training module.

An assumption about the iRODS service account's Linux user ID: that it will always be 999. This adds a build argument for the iRODS service account user ID and group ID so that the build of the image can be run like this, from the build context:

```bash
docker build \
    --build-arg irods_uid=$(id -u irods) \
    --build-arg irods_gid=$(id -g irods) \
    -t testimages/jupyter-digital-filter .
```

---

This needs to be accompanied with some changes to the slides; specifically, the `docker build` step, as described in the commit message.