### PR TITLE
rectify slow docker execution for chown -R  <LARGE_DIRECTORY>

### DIFF
--- a/advanced/hpc_compute_to_data/jupyter_notebook/Dockerfile
+++ b/advanced/hpc_compute_to_data/jupyter_notebook/Dockerfile
@@ -23,7 +23,13 @@ COPY mymodule/ /home/jovyan/work/mymodule
 
 RUN chown -R jovyan.users /home/jovyan/work/mymodule
 
-RUN chown -R ${IRODS_UID}:${IRODS_GID} /home/jovyan && chown -R ${IRODS_UID}:${IRODS_GID} /opt/conda
+RUN chown -R ${IRODS_UID}:${IRODS_GID} /home/jovyan
+
+COPY copy_files_with_new_owner_and_group /
+
+RUN cd /opt && mv conda conda.old && mkdir conda && chown ${IRODS_UID}:${IRODS_GID} conda &&\
+    /copy_files_with_new_owner_and_group -u ${IRODS_UID} -g ${IRODS_GID} conda.old conda &&\
+    rm -fr conda.old
 
 USER jovyan
 

--- a/advanced/hpc_compute_to_data/jupyter_notebook/copy_files_with_new_owner_and_group
+++ b/advanced/hpc_compute_to_data/jupyter_notebook/copy_files_with_new_owner_and_group
@@ -1,0 +1,31 @@
+#!/bin/bash
+OWNER_U=
+OWNER_G=
+
+usage() {
+  echo "$0 -u <DEST_OWNER_USER> -g <DEST_OWNER_GROUP> <SRCDIR> <DESTDIR>"
+  exit 1;
+}
+
+# Process options to set owning user (-u) and group (-g) of destination tree.
+
+while [[ $1 = -* ]] ; do
+  if [ "$1" = "-g" ]; then
+    OWNER_G="$2"; shift 2
+  fi
+  if [ "$1" = "-u" ]; then
+    OWNER_U="$2"; shift 2
+  fi
+done
+
+# Print usage if wrong number of options, or if either of -u or -g is omitted.
+
+[ $# -ne 2 -o  \
+  -z "$OWNER_U" -o \
+  -z "$OWNER_G" ] && { usage; }
+
+# Copy source tree to destination tree, applying tar's ability to modify the owning user and group.
+
+(cd $1 && tar --owner=$OWNER_U --group=$OWNER_G -cf - .) |\
+(cd $2 && sudo tar  -xf - .)
+


### PR DESCRIPTION
On ubuntu22.04, a recursive chown -R of a large directory tree is far too slow.  This is causing  excessive image build times in compute-to-data.  The proposed step should be equivalent, and shortens this time to mere seconds.