### PR TITLE
Split compute-to-data docker build into two parts.

### DIFF
--- a/advanced/hpc_compute_to_data/jupyter_notebook/Dockerfile
+++ b/advanced/hpc_compute_to_data/jupyter_notebook/Dockerfile
@@ -1,42 +1,15 @@
 FROM jupyter/base-notebook
 
-ARG  irods_uid=997
-ENV  IRODS_UID ${irods_uid}
-ARG  irods_gid=998
-ENV  IRODS_GID ${irods_gid}
-
-USER root
-
-RUN apt-get update && apt-get install -y vim less
-
-RUN groupadd -g $IRODS_GID irods && usermod -aG irods jovyan 
-
-RUN sed -i "s/jovyan:x:[0-9]*:[0-9]*\(.*\)/jovyan:x:${IRODS_UID}:${IRODS_GID}\1/" /etc/passwd
-
-ADD lpfilter.ipynb /home/jovyan/work/.
-
-COPY mymodule/ /home/jovyan/work/mymodule/
-
-RUN chown jovyan.users /home/jovyan/work/lpfilter.ipynb
-
-COPY mymodule/ /home/jovyan/work/mymodule
-
-RUN chown -R jovyan.users /home/jovyan/work/mymodule
-
-RUN chown -R ${IRODS_UID}:${IRODS_GID} /home/jovyan
-
-COPY copy_files_with_new_owner_and_group /
-
-RUN cd /opt && mv conda conda.old && mkdir conda && chown ${IRODS_UID}:${IRODS_GID} conda &&\
-    /copy_files_with_new_owner_and_group -u ${IRODS_UID} -g ${IRODS_GID} conda.old conda &&\
-    rm -fr conda.old
-
-USER jovyan
-
 RUN conda init
 
 RUN conda install -y -c conda-forge matplotlib numpy
 
-RUN jupyter trust /home/jovyan/work/lpfilter.ipynb
+USER jovyan
 
-CMD [ '/bin/bash' ]
+COPY mymodule/ /home/jovyan/work/mymodule/
+#RUN chown jovyan.users /home/jovyan/work/lpfilter.ipynb
+ADD lpfilter.ipynb /home/jovyan/work/.
+RUN jupyter trust /home/jovyan/work/lpfilter.ipynb
+COPY mymodule/ /home/jovyan/work/mymodule
+#RUN chown -R jovyan.users /home/jovyan/work/mymodule
+

--- a/advanced/hpc_compute_to_data/jupyter_notebook/Dockerfile.2
+++ b/advanced/hpc_compute_to_data/jupyter_notebook/Dockerfile.2
@@ -1,0 +1,28 @@
+from dwmoore/intermediate-notebook
+
+ARG  irods_uid
+ENV  IRODS_UID ${irods_uid}
+ARG  irods_gid
+ENV  IRODS_GID ${irods_gid}
+
+USER root
+
+RUN apt-get update && apt-get install -y vim less
+
+RUN groupadd -g $IRODS_GID irods && usermod -aG irods jovyan 
+
+RUN find / -xdev -user jovyan|egrep -v '^\/opt\/conda' |tr '\n' '\0' >/tmp/jovyan.files
+
+RUN sed -i "s/jovyan:x:[0-9]*:[0-9]*\(.*\)/jovyan:x:${IRODS_UID}:${IRODS_GID}\1/" /etc/passwd
+
+RUN xargs -r0 chown ${IRODS_UID}:${IRODS_GID} </tmp/jovyan.files
+
+COPY copy_files_with_new_owner_and_group /
+
+RUN cd /opt && mv conda conda.old && mkdir conda && chown ${IRODS_UID}:${IRODS_GID} conda &&\
+    /copy_files_with_new_owner_and_group -u ${IRODS_UID} -g ${IRODS_GID} conda.old conda &&\
+    rm -fr conda.old
+
+USER ${IRODS_UID}
+
+CMD [ '/bin/bash' ]

--- a/advanced/hpc_compute_to_data/jupyter_notebook/README.md
+++ b/advanced/hpc_compute_to_data/jupyter_notebook/README.md
@@ -1,0 +1,19 @@
+
+Sequence for building.
+---------------------
+
+Part one: the published image.
+
+   - Built the time-consuming part of the docker image (the conda install is the culprit!):
+     ```
+     docker build -t dwmoore/intermediate-notebook -f Dockerfile .
+     ```
+   - Pushed dwmoore/intermediate-notebook to Docker Hub.
+
+Part two: the local GID/UID customized image
+
+   - 
+     ```
+     docker build -t testimages/jupyter-digital-filter . -f Dockerfile.2 --build-arg irods_uid=$(id -u irods) --build-arg irods_gid=$(id -g irods)
+     ```
+


### PR DESCRIPTION
Docker hub will contain the conda install section (takes 8 min on an AWS VM) This will be built on during the training by adding the UID/GID chown treatment.