### PR TITLE
Get FQDN instead of hostname for detecting local resc

### DIFF
--- a/advanced/hpc_compute_to_data/compute_to_data_support.py
+++ b/advanced/hpc_compute_to_data/compute_to_data_support.py
@@ -68,7 +68,7 @@ def this_host_tied_to_resc_R( args, callback, rei ): # test rule
 
 def this_host_tied_to_resc(callback, resc ):
     import socket
-    this_host = socket.gethostname()
+    this_host = socket.getfqdn()
     tied_host = ""
     for rescvault in row_iterator( 'RESC_LOC',"RESC_NAME = '{resc}'".format(**locals()), AS_DICT,callback):
         tied_host = rescvault['RESC_LOC']


### PR DESCRIPTION
The python rule will not run if a remote resc is detected, but it erroneously will not detect itself if FQDN is used to set up the resc. However, FQDN is needed now because of the self-loop logic for the server, so FQDN is used here to match. 