### PR TITLE
[#82] Add setup/teardown plugin operations to storage balancing plugin (main)

### DIFF
--- a/advanced/irods_rule_engine_plugin_storage_balancing/src/libirods_rule_engine_plugin-cpp-storage-balancing.cpp
+++ b/advanced/irods_rule_engine_plugin_storage_balancing/src/libirods_rule_engine_plugin-cpp-storage-balancing.cpp
@@ -192,6 +192,16 @@ namespace {
 }
 
 static
+irods::error setup(irods::default_re_ctx&, const std::string&) {
+    return SUCCESS();
+}
+
+static
+irods::error teardown(irods::default_re_ctx&, const std::string&) {
+    return SUCCESS();
+}
+
+static
 irods::error start(irods::default_re_ctx&, const std::string&) {
     RuleExistsHelper::Instance()->registerRuleRegex( "[^ ]*pep_resource_resolve_hierarchy_pre" );
     return SUCCESS();
@@ -280,6 +290,12 @@ extern "C"
 irods::pluggable_rule_engine<irods::default_re_ctx>* plugin_factory(const std::string& _instance_name,
                                  const std::string& _context) {
     auto re{new irods::pluggable_rule_engine<irods::default_re_ctx>(_instance_name , _context)};
+    re->add_operation(
+            "setup",
+            std::function<irods::error(irods::default_re_ctx&, const std::string&)>(setup));
+    re->add_operation(
+            "teardown",
+            std::function<irods::error(irods::default_re_ctx&, const std::string&)>(teardown));
     re->add_operation(
             "start",
             std::function<irods::error(irods::default_re_ctx&, const std::string&)>(start));


### PR DESCRIPTION
Code compiles and matches instances seen in other plugins (e.g. PREP).

This code aligns with expectations of iRODS 5 and the training slides.